### PR TITLE
Remove wildcard COPY commands from Dockerfile

### DIFF
--- a/docker/Dockerfile.train.multistage
+++ b/docker/Dockerfile.train.multistage
@@ -80,8 +80,6 @@ COPY --from=flash-attention-builder /usr/local/bin /usr/local/bin
 
 # Copy dependency files first
 COPY pyproject.toml /workspace/
-COPY requirements.txt* /workspace/
-COPY setup.py* /workspace/
 
 # Install other dependencies (Flash Attention will be skipped since it's already installed)
 RUN pip install -e .[train]


### PR DESCRIPTION
The CogACT repo uses `pyproject.toml` for managing dependencies, rather than `requirements.txt`. In the current Dockerfile, the wildcard COPY commands that look for `requirements.txt` and `setup.py` will throw an error. The Docker build succeeds after removing these lines.

![copy_failed](https://github.com/user-attachments/assets/2095ea00-f219-4bb6-a6c3-8f273b1fb40a)
